### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/joezha/4dbe3d61-ea17-404e-b205-2f6fd0c54b0c/b0f35adc-fc81-478f-886b-f4c4ef0773a0/_apis/work/boardbadge/ac2d2446-db0e-48d0-bd87-481371008434)](https://codedev.ms/joezha/4dbe3d61-ea17-404e-b205-2f6fd0c54b0c/_boards/board/t/b0f35adc-fc81-478f-886b-f4c4ef0773a0/Microsoft.RequirementCategory)
 # chench


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#2. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.